### PR TITLE
[Fast Track]: Add uv setup to PATH

### DIFF
--- a/zsh/.zshrc.d/00-env.zsh
+++ b/zsh/.zshrc.d/00-env.zsh
@@ -9,3 +9,6 @@ fi
 
 # cargo
 [ -f "$HOME/.cargo/env" ] && source "$HOME/.cargo/env"
+
+# uv
+[ -f "$HOME/.local/bin/env" ] && source "$HOME/.local/bin/env"


### PR DESCRIPTION
Closes #15

## Overview
Incorporates the local `uv` configuration (`~/.local/bin/env`) into the `main` branch by sourcing it within `zsh/.zshrc.d/00-env.zsh`.

## Changes
- Modifies `zsh/.zshrc.d/00-env.zsh` to source `uv` path.

## Notes
Generated via Fast Track script.