### PR TITLE
[Fast Track] Remove pyenv from 00-env.zsh

### DIFF
--- a/zsh/.zshrc.d/00-env.zsh
+++ b/zsh/.zshrc.d/00-env.zsh
@@ -1,12 +1,5 @@
 # 00-env.zsh
 
-# pyenv
-export PYENV_ROOT="$HOME/.pyenv"
-if [[ -d $PYENV_ROOT/bin ]]; then
-    export PATH="$PYENV_ROOT/bin:$PATH"
-    eval "$(pyenv init - zsh)"
-fi
-
 # cargo
 [ -f "$HOME/.cargo/env" ] && source "$HOME/.cargo/env"
 


### PR DESCRIPTION
Closes #19

## Overview
Remove pyenv configuration from `00-env.zsh` to unify Python toolchain under uv only.

## Changes
- Remove pyenv block (`PYENV_ROOT`, `PATH` export, `pyenv init`) from `zsh/.zshrc.d/00-env.zsh`

## Notes
uv handles Python version management going forward. The uv sourcing block is retained.