### PR TITLE
Remove SSH URL rewrite from gitconfig

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -7,5 +7,9 @@
 	editor = code --wait
 [push]
 	autoSetupRemote = true
-[url "git@github.com:"]
-	insteadOf = https://github.com/
+[credential "https://github.com"]
+	helper = 
+	helper = !/usr/bin/gh auth git-credential
+[credential "https://gist.github.com"]
+	helper = 
+	helper = !/usr/bin/gh auth git-credential


### PR DESCRIPTION
Closes #24

## Overview
Remove the SSH URL rewrite block from `.gitconfig`. Git authentication via HTTPS now uses the GitHub CLI credential helper (`gh auth setup-git`).

## Changes
- Remove `[url "git@github.com:"] insteadOf = https://github.com/` from `git/.gitconfig`

## Notes
This change was needed after switching from SSH key-based auth to `gh auth setup-git` for HTTPS authentication.