### PR TITLE
Add nvm configuration to zsh dotfiles

### DIFF
--- a/zsh/.zshrc.d/50-nvm.zsh
+++ b/zsh/.zshrc.d/50-nvm.zsh
@@ -1,0 +1,6 @@
+# 50-nvm.zsh
+
+# nvm
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
+[ -s "$NVM_DIR/bash_completion" ] && source "$NVM_DIR/bash_completion"


### PR DESCRIPTION
Closes #26

## Overview
Add nvm initialization to the zsh dotfiles via a new `50-nvm.zsh` file in `.zshrc.d/`.

## Changes
- Add `zsh/.zshrc.d/50-nvm.zsh` with `NVM_DIR` export and nvm/bash_completion sourcing

## Notes
Follows the existing pattern in `00-env.zsh` of guarding sources with `[ -s ... ]` checks.