### PR TITLE
#31 Add compinit initialization to 30-completion.zsh

### DIFF
--- a/zsh/.zshrc.d/30-completion.zsh
+++ b/zsh/.zshrc.d/30-completion.zsh
@@ -1,0 +1,3 @@
+# 30-completion.zsh
+autoload -Uz compinit
+compinit

--- a/zsh/.zshrc.d/30-completion.zsh
+++ b/zsh/.zshrc.d/30-completion.zsh
@@ -1,3 +1,4 @@
 # 30-completion.zsh
+
 autoload -Uz compinit
 compinit

--- a/zsh/.zshrc.d/30-options.zsh
+++ b/zsh/.zshrc.d/30-options.zsh
@@ -1,1 +1,0 @@
-# 30-options.zsh


### PR DESCRIPTION
Closes #31

## Overview
Adds `compinit` initialization to enable zsh's built-in completion system. Renames `30-options.zsh` to `30-completion.zsh` to better reflect the file's purpose.

## Changes
- Rename `30-options.zsh` to `30-completion.zsh`
- Add `autoload -Uz compinit` and `compinit` to `30-completion.zsh`

## Notes
`compinit` is zsh's built-in completion system (not a plugin), so it belongs before `40-plugins.zsh` where completion-dependent plugins like `zsh-autosuggestions` are sourced.