### PR TITLE
Replace eza -F flag with --classify=auto in aliases

### DIFF
--- a/zsh/.zshrc.d/20-aliases.zsh
+++ b/zsh/.zshrc.d/20-aliases.zsh
@@ -14,8 +14,8 @@ fi
 
 # ls
 if command -v eza > /dev/null; then
-    alias ls='eza --group-directories-first -F'
-    alias tree='eza --group-directories-first -F -TL 3'
+    alias ls='eza --group-directories-first --classify=auto'
+    alias tree='eza --group-directories-first --classify=auto -TL 3'
 elif command -v ls > /dev/null; then
     alias ls='ls --group-directories-first -F'
 fi


### PR DESCRIPTION
Closes #33

## Overview
Replace the deprecated `-F` shorthand with `--classify=auto` in eza aliases.

## Changes
- Replace `-F` with `--classify=auto` in the `ls` alias
- Replace `-F` with `--classify=auto` in the `tree` alias

## Notes
`--classify=auto` is the explicit, non-deprecated equivalent that only appends type indicators when outputting to a terminal.