### PR TITLE
Normalize deno env sourcing in 00-env.zsh

### DIFF
--- a/zsh/.zshrc.d/00-env.zsh
+++ b/zsh/.zshrc.d/00-env.zsh
@@ -13,3 +13,6 @@ export PATH="$HOME/.local/bin:$PATH"
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
 [ -s "$NVM_DIR/bash_completion" ] && source "$NVM_DIR/bash_completion"
+
+# deno
+[ -f "$HOME/.deno/env" ] && source "$HOME/.deno/env"


### PR DESCRIPTION
Closes #35

## Overview
Normalize the deno env entry to match the guard pattern used by cargo, uv, and nvm.

## Changes
- Replace hardcoded `/home/tatsuzaki98/.deno/env` with `$HOME/.deno/env`
- Add `[ -f ... ] &&` existence guard
- Use `source` instead of `.`

## Notes
No behavior change on machines where `~/.deno/env` exists; silently skips on machines without Deno installed.