### PR TITLE
Move local bin PATH export to top of 00-env.zsh

### DIFF
--- a/zsh/.zshrc.d/00-env.zsh
+++ b/zsh/.zshrc.d/00-env.zsh
@@ -1,13 +1,13 @@
 # 00-env.zsh
 
+# local bin
+export PATH="$HOME/.local/bin:$PATH"
+
 # cargo
 [ -f "$HOME/.cargo/env" ] && source "$HOME/.cargo/env"
 
 # uv
 [ -f "$HOME/.local/bin/env" ] && source "$HOME/.local/bin/env"
-
-# local bin
-export PATH="$HOME/.local/bin:$PATH"
 
 # nvm
 export NVM_DIR="$HOME/.nvm"


### PR DESCRIPTION
Closes #37

## Overview
Move `export PATH="$HOME/.local/bin:$PATH"` before other tool env sources so the PATH is set before any tool binaries in that directory are invoked.

## Changes
- Move `# local bin` block to the top of `00-env.zsh`

## Notes
No behavior change in practice, but the ordering now reflects the intended initialization sequence.