### PR TITLE
Add --git-ignore, -a, and --ignore-glob flags to tree alias

### DIFF
--- a/zsh/.zshrc.d/20-aliases.zsh
+++ b/zsh/.zshrc.d/20-aliases.zsh
@@ -15,7 +15,7 @@ fi
 # ls
 if command -v eza > /dev/null; then
     alias ls='eza --group-directories-first --classify=auto'
-    alias tree='eza --group-directories-first --classify=auto -TL 3'
+    alias tree='eza --group-directories-first --classify=auto -TL 3 --git-ignore -a --ignore-glob=".git"'
 elif command -v ls > /dev/null; then
     alias ls='ls --group-directories-first -F'
 fi


### PR DESCRIPTION
Closes #39

## Overview
Update the `tree` alias to include flags for hiding git-ignored files, showing hidden files, and excluding the `.git` directory.

## Changes
- Added `--git-ignore -a --ignore-glob=".git"` to the `tree` alias in `zsh/.zshrc.d/20-aliases.zsh`

## Notes
N/A