### PR TITLE
Add gh issue and pull request list aliases

### DIFF
--- a/zsh/.zshrc.d/20-aliases.zsh
+++ b/zsh/.zshrc.d/20-aliases.zsh
@@ -21,3 +21,7 @@ elif command -v ls > /dev/null; then
 fi
 alias ll='ls -hal --git'
 alias la='ls -a'
+
+# gh
+alias ghil='gh issue list --json number,title,url --jq '\''.[] | "#\(.number) \(.title) \(.url)"'\'''
+alias ghpl='gh pr list --json number,title,url --jq '\''.[] | "#\(.number) \(.title) \(.url)"'\'''


### PR DESCRIPTION
Closes #41

## Overview
Add zsh aliases for compact GitHub issue and pull request list output.

## Changes
- Add ghil for gh issue list output with number, title, and URL.
- Add ghpl for gh pr list output with number, title, and URL.

## Notes
Validated with zsh -n zsh/.zshrc.d/20-aliases.zsh.