### PR TITLE
Add pnpm PATH config to 00-env.zsh

### DIFF
--- a/zsh/.zshrc.d/00-env.zsh
+++ b/zsh/.zshrc.d/00-env.zsh
@@ -16,3 +16,10 @@ export NVM_DIR="$HOME/.nvm"
 
 # deno
 [ -f "$HOME/.deno/env" ] && source "$HOME/.deno/env"
+
+# pnpm
+export PNPM_HOME="$HOME/.local/share/pnpm"
+case ":$PATH:" in
+  *":$PNPM_HOME/bin:"*) ;;
+  *) export PATH="$PNPM_HOME/bin:$PATH" ;;
+esac


### PR DESCRIPTION
Closes #45

## Overview
Add pnpm `PNPM_HOME` export and PATH setup to `zsh/.zshrc.d/00-env.zsh`. This keeps the pnpm initialization alongside the other environment-manager entries (cargo, uv, nvm, deno) and avoids having the pnpm installer write the block directly into `.zshrc`.

## Changes
- Appended pnpm block to `zsh/.zshrc.d/00-env.zsh` using `$HOME` (no hardcoded absolute paths)

## Notes
- `$PNPM_HOME/bin` is the correct PATH entry — pnpm stores its executables under `~/.local/share/pnpm/bin/`.