### PR TITLE
#47 Add zshrc.local.d for untracked local zsh config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /tmp/
 
 .vscode/settings.json
+
+zsh/.zshrc.local.d/*
+!zsh/.zshrc.local.d/.gitkeep

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,7 +1,8 @@
-if [ -d "$HOME/.zshrc.d" ]; then
-    for f in ~/.zshrc.d/*.zsh; do
+for dir in "$HOME/.zshrc.d" "$HOME/.zshrc.local.d"; do
+    [ -d "$dir" ] || continue
+    for f in "$dir"/*.zsh(N); do
         printf "Loading: %-30s " "${f:t}..."
         source "$f"
         printf "done\n"
     done
-fi
+done


### PR DESCRIPTION
Closes #47

## Overview
Introduce a sibling `~/.zshrc.local.d/` directory for per-machine zsh snippets that should not be committed to the dotfiles repo (e.g. host-specific aliases such as a Windows reboot helper).

## Changes
- `zsh/.zshrc`: source `*.zsh` from both `~/.zshrc.d/` and `~/.zshrc.local.d/`, using the `(N)` glob qualifier so an empty local dir does not error.
- `zsh/.zshrc.local.d/.gitkeep`: keep the directory in the tree so `stow` can symlink it into `$HOME`.
- `.gitignore`: ignore everything under `zsh/.zshrc.local.d/` except `.gitkeep`.

## Notes
- Verified locally: `stow --restow zsh` creates `~/.zshrc.local.d` symlink, and a sample alias placed in the local directory is loaded by a new interactive shell.