### PR TITLE
#51 Add pre-commit hooks for file hygiene

### DIFF
--- a/.github/manuals/pre-commit.md
+++ b/.github/manuals/pre-commit.md
@@ -1,0 +1,18 @@
+# pre-commit
+
+Local file-hygiene checks. Hooks are defined in
+[.pre-commit-config.yaml](/.pre-commit-config.yaml) and enforced in CI by
+[.github/workflows/lint.yml](/.github/workflows/lint.yml).
+
+## Commands
+
+```sh
+# Install the git hook in this repository (run once per clone)
+uvx pre-commit install
+
+# Run all hooks against all files
+uvx pre-commit run --all-files
+
+# Bump pinned hook versions in .pre-commit-config.yaml
+uvx pre-commit autoupdate
+```

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    timeout-minutes: 10
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "0.11.7"
+
+      - name: Run pre-commit
+        run: uvx pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-json

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -8,8 +8,8 @@
 [push]
 	autoSetupRemote = true
 [credential "https://github.com"]
-	helper = 
+	helper =
 	helper = !/usr/bin/gh auth git-credential
 [credential "https://gist.github.com"]
-	helper = 
+	helper =
 	helper = !/usr/bin/gh auth git-credential


### PR DESCRIPTION
Closes #51

## Summary

Add the standard `pre-commit-hooks` set and a CI job to enforce them. Work completed as planned.

## Background

The repository has no automated file-hygiene checks. Drift in line endings, trailing whitespace, and malformed YAML/JSON should be caught before review. Add the standard `pre-commit-hooks` set, and wire the runner into `.github/` so CI enforces the same checks.

Spun out from #49.

## Target

- `.pre-commit-config.yaml`
- `.github/workflows/lint.yml`
- `.github/manuals/pre-commit.md`
- `git/.gitconfig` (cleanup flagged by the new hooks)

## Changes

- [x] Add `.pre-commit-config.yaml` with hooks: `end-of-file-fixer`, `trailing-whitespace`, `check-yaml`, `check-json` (pinned to `pre-commit-hooks` v6.0.0)
- [x] Add `.github/workflows/lint.yml` that runs `pre-commit` on PRs and on push to `main` via `uvx`
- [x] Document the local setup in `.github/manuals/pre-commit.md`

## Notes

- The original Issue named the workflow file under `.github/workflows/`; concrete filename landed as `lint.yml` with workflow name `Lint`.
- The Issue suggested `pip install pre-commit`; CI uses `astral-sh/setup-uv` + `uvx pre-commit run --all-files` instead, and the manual recommends `uvx` for local runs as well.
- Path scoping for the workflow was dropped because `trailing-whitespace` / `end-of-file-fixer` apply to any text file, so a path filter would create false negatives.
- `git/.gitconfig` had two trailing spaces flagged by the new hooks; included as a separate commit so CI passes on this PR.
- Verified locally: `uvx pre-commit run --all-files` passes.